### PR TITLE
Add frontend docs and job stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 *   **Хранение данных:** TypeORM для взаимодействия с реляционной базой данных.
 *   **Мониторинг в реальном времени (SSE):**
     *   Подписка на обновления конкретной задачи: `GET /api/sse/:id`
-    *   Подписка на обновления всех задач: `GET /api/sse/all` (события `job-update`, `job-done`, `job-canceled`)
+    *   Подписка на обновления всех задач: `GET /api/sse/all` (события `job-updated`, `job-done`, `job-canceled`)
 *   **API:**
     *   Базовая проверка: `GET /api`
     *   Создать задачу: `POST /api/jobs`
@@ -43,25 +43,35 @@
 *   **Запуск unit-тестов:**
     ```bash
     npx nx test backend
+    # или
+    npm test backend
     ```
 *   **Запуск E2E-тестов:**
     ```bash
     npx nx e2e backend-e2e
     ```
 
-### `frontend` (TODO)
+### `frontend`
 
-*Описание будущего фронтенд-приложения будет добавлено здесь.*
+Интерфейс панели управления построен на **React** и **Vite** с использованием
+**Tailwind CSS** и компонентов [shadcn/ui](https://ui.shadcn.com/). Данные
+загружаются через **TanStack&nbsp;Query**, маршрутизация реализована при помощи
+**React Router**.
 
-<!-- *   **Технологии:** React/Vue/Angular, TypeScript, etc.
-*   **Разработка:**
-    ```bash
-    npx nx serve frontend
-    ```
-*   **Сборка:**
-    ```bash
-    npx nx build frontend
-    ``` -->
+**Запуск в режиме разработки:**
+
+```bash
+npx nx serve frontend
+```
+
+**Сборка:**
+
+```bash
+npx nx build frontend
+```
+
+Основные зависимости: React&nbsp;19, TanStack&nbsp;Query&nbsp;v5, shadcn/ui,
+react-hook-form, zod, Zustand.
 
 ## Библиотеки
 

--- a/apps/backend-e2e/src/backend/backend.spec.ts
+++ b/apps/backend-e2e/src/backend/backend.spec.ts
@@ -45,7 +45,7 @@ describe('Job API', () => {
       console.error('SSE error:', err);
       eventSource.close();
     };
-    eventSource.addEventListener('job-update', (event) => {
+    eventSource.addEventListener('job-updated', (event) => {
       const data = JSON.parse(event.data);
       progress = data.progress;
     });
@@ -80,7 +80,7 @@ describe('Job API', () => {
       `${axios.defaults.baseURL}/sse/${jobId}`
     );
 
-    eventSource.addEventListener('job-update', (event) => {
+    eventSource.addEventListener('job-updated', (event) => {
       const job: Job = JSON.parse(event.data);
       eventCount++;
       expect(job.id).toBe(jobId);
@@ -175,7 +175,7 @@ describe('GET /sse/all', () => {
 
     let receivedJobUpdateForSpecificId = false;
 
-    eventSource.addEventListener('job-update', (event) => {
+    eventSource.addEventListener('job-updated', (event) => {
       const data = JSON.parse(event.data);
       if (data.id === jobIdForSseAll) {
         receivedJobUpdateForSpecificId = true;

--- a/apps/backend/src/job/job.controller.spec.ts
+++ b/apps/backend/src/job/job.controller.spec.ts
@@ -168,4 +168,15 @@ describe('JobController', () => {
       expect(result.running.averageProgress).toBeCloseTo(40); // (20 + 40 + 60) / 3
     });
   });
+
+  describe('getStats', () => {
+    it('should parse range and call jobService.getStats', async () => {
+      const getStats = jest
+        .spyOn(jobService as any, 'getStats')
+        .mockResolvedValue([]);
+
+      await controller.getStats('5d');
+      expect(getStats).toHaveBeenCalledWith(5);
+    });
+  });
 });

--- a/apps/backend/src/job/job.controller.ts
+++ b/apps/backend/src/job/job.controller.ts
@@ -70,6 +70,13 @@ export class JobController {
     };
   }
 
+  @Get('stats')
+  async getStats(@Query('range') range = '7d') {
+    const match = /^(\d+)d$/.exec(range ?? '7d');
+    const days = match ? parseInt(match[1], 10) : 7;
+    return this.jobService.getStats(days);
+  }
+
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<Job> {
     return this.jobService.findOne(id);

--- a/apps/backend/src/job/job.service.spec.ts
+++ b/apps/backend/src/job/job.service.spec.ts
@@ -217,7 +217,7 @@ describe('JobService', () => {
     );
   });
 
-  it('should call subscriber with event "job-update"', async () => {
+  it('should call subscriber with event "job-updated"', async () => {
     const callback = jest.fn();
     service.subscribeToJob(mockJob.id, callback);
 
@@ -225,7 +225,7 @@ describe('JobService', () => {
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({ progress: 50 }),
-      'job-update'
+      'job-updated'
     );
   });
 
@@ -261,7 +261,7 @@ describe('JobService', () => {
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({ progress: 50 }),
-      'job-update'
+      'job-updated'
     );
   });
 
@@ -274,5 +274,18 @@ describe('JobService', () => {
 
     expect(service['subscribers'].get('1')).toBeUndefined();
     expect(service['subscribers'].get('2')).toBeUndefined();
+  });
+
+  it('should calculate stats for given range', async () => {
+    const jobs: Job[] = [
+      { ...mockJob, createdAt: new Date(), status: JobStatus.Done },
+      { ...mockJob, createdAt: new Date(), status: JobStatus.Failed },
+    ];
+
+    repository.find = jest.fn().mockResolvedValue(jobs);
+
+    const stats = await service.getStats(1);
+    expect(stats[0].done).toBe(1);
+    expect(stats[0].failed).toBe(1);
   });
 });

--- a/apps/backend/src/sse/sse.controller.spec.ts
+++ b/apps/backend/src/sse/sse.controller.spec.ts
@@ -96,10 +96,10 @@ describe('SseController', () => {
       // Имитируем обновление задачи
       const callback = (jobService.subscribeToJob as jest.Mock).mock
         .calls[0][1];
-      callback(mockJob, 'job-update');
+      callback(mockJob, 'job-updated');
 
       expect(mockRes.write).toHaveBeenCalledWith(
-        `event: job-update\ndata: ${JSON.stringify(mockJob)}\n\n`
+        `event: job-updated\ndata: ${JSON.stringify(mockJob)}\n\n`
       );
     });
 

--- a/apps/frontend/src/routes/[...all].tsx
+++ b/apps/frontend/src/routes/[...all].tsx
@@ -2,7 +2,7 @@ export default function NotFound() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Страница не найдена</h1>
-      <p>Ашипка</p>
+      <p>Ошибка</p>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@async-workers/source",
   "version": "0.0.0",
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "test": "nx test",
+    "build": "nx build"
+  },
   "private": true,
   "dependencies": {
     "@nestjs/common": "^11.1.4",


### PR DESCRIPTION
## Summary
- document frontend stack and usage
- rename SSE event to `job-updated`
- implement `/api/jobs/stats` endpoint
- fix typo on NotFound page
- add basic Nx scripts

## Testing
- `nx test backend` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824f0ec4a88330a7b2aad10358501a