### PR TITLE
Frontend (fix): handle api errors

### DIFF
--- a/apps/frontend/src/routes/jobs/[id].tsx
+++ b/apps/frontend/src/routes/jobs/[id].tsx
@@ -19,21 +19,29 @@ export default function JobDetailsPage() {
   if (!job) return <div>Задача не найдена</div>;
 
   const handleStartJob = async () => {
-    await DataAccess.startJob(job.id, () =>
-      toast({
-        title: 'Job started',
-        description: job.name,
-      })
-    );
+    try {
+      await DataAccess.startJob(job.id, () =>
+        toast({
+          title: 'Job started',
+          description: job.name,
+        })
+      );
+    } catch (e) {
+      toast({ title: 'Ошибка запуска', variant: 'destructive' });
+    }
   };
 
   const handleCancelJob = async () => {
-    await DataAccess.cancelJob(job.id, () =>
-      toast({
-        title: 'Job canceled',
-        description: job.name,
-      })
-    );
+    try {
+      await DataAccess.cancelJob(job.id, () =>
+        toast({
+          title: 'Job canceled',
+          description: job.name,
+        })
+      );
+    } catch (e) {
+      toast({ title: 'Ошибка отмены', variant: 'destructive' });
+    }
   };
 
   return (

--- a/libs/dataAccess/.spec.swcrc
+++ b/libs/dataAccess/.spec.swcrc
@@ -1,0 +1,19 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": false,
+      "dynamicImport": true
+    },
+    "transform": {},
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": []
+}

--- a/libs/dataAccess/jest.config.ts
+++ b/libs/dataAccess/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+const swcJestConfig = JSON.parse(readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8'));
+
+swcJestConfig.swcrc = false;
+
+export default {
+  displayName: '@async-workers/data-access',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: 'test-output/jest/coverage',
+};

--- a/libs/dataAccess/src/lib/data-access.spec.ts
+++ b/libs/dataAccess/src/lib/data-access.spec.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import DataAccess from './data-access';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('DataAccess', () => {
+  beforeEach(() => {
+    mockedAxios.create.mockReturnValue(mockedAxios);
+  });
+
+  it('should reject with message when request fails', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'));
+    await expect(DataAccess.getAllJobs()).rejects.toBe('fail');
+  });
+});

--- a/libs/dataAccess/src/lib/data-access.ts
+++ b/libs/dataAccess/src/lib/data-access.ts
@@ -9,48 +9,86 @@ import {
 class DataAccess {
   private API = axios.create({ baseURL: '/api' });
 
+  private handleError = (err: unknown): Promise<never> => {
+    if (axios.isAxiosError(err)) {
+      return Promise.reject(err.response?.data?.message ?? err.message);
+    }
+    if (err instanceof Error) {
+      return Promise.reject(err.message);
+    }
+    return Promise.reject(String(err));
+  };
+
   public getAllJobs = async (status?: JobStatus): Promise<Job[]> => {
-    const { data } = await this.API.get<Job[]>('/jobs', {
-      params: { status },
-    });
-    return data;
+    try {
+      const { data } = await this.API.get<Job[]>('/jobs', {
+        params: { status },
+      });
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public getJobById = async (id: Nullish<string>): Promise<Job> => {
     if (!id) {
-      throw new Error('Job ID is required');
+      return Promise.reject('Job ID is required');
     }
-    const { data } = await this.API.get<Job>(`/jobs/${id}`);
-    return data;
+    try {
+      const { data } = await this.API.get<Job>(`/jobs/${id}`);
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public createJob = async (name: string): Promise<Job> => {
-    const { data } = await this.API.post<Job>('/jobs', { name });
-    return data;
+    try {
+      const { data } = await this.API.post<Job>('/jobs', { name });
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public getJobsSummary = async (): Promise<JobsSummary> => {
-    const { data } = await this.API.get<JobsSummary>('/jobs/summary');
-    return data;
+    try {
+      const { data } = await this.API.get<JobsSummary>('/jobs/summary');
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public getJobsStats = async (days = 7): Promise<JobsStats[]> => {
-    const { data } = await this.API.get<JobsStats[]>(`/jobs/stats`, {
-      params: { days },
-    });
-    return data;
+    try {
+      const { data } = await this.API.get<JobsStats[]>(`/jobs/stats`, {
+        params: { days },
+      });
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public startJob = async (jobId: string, cb?: () => void): Promise<Job> => {
-    const { data } = await this.API.post<Job>(`/jobs/${jobId}/start`);
-    cb?.();
-    return data;
+    try {
+      const { data } = await this.API.post<Job>(`/jobs/${jobId}/start`);
+      cb?.();
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 
   public cancelJob = async (jobId: string, cb?: () => void): Promise<Job> => {
-    const { data } = await this.API.post<Job>(`/jobs/${jobId}/cancel`);
-    cb?.();
-    return data;
+    try {
+      const { data } = await this.API.post<Job>(`/jobs/${jobId}/cancel`);
+      cb?.();
+      return data;
+    } catch (err) {
+      return this.handleError(err);
+    }
   };
 }
 

--- a/libs/dataAccess/tsconfig.spec.json
+++ b/libs/dataAccess/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "types": ["jest", "node"],
+    "esModuleInterop": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.d.ts",
+    "../../types.d.ts"
+  ],
+  "references": [
+    { "path": "./tsconfig.json" }
+  ]
+}


### PR DESCRIPTION
## Summary
- handle axios errors in `DataAccess`
- show error toasts when starting/canceling jobs
- add `DataAccess` tests

## Testing
- `npx nx test @async-workers/data-access --list-tests` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688962c6a8f08330b3677ff20251d3f8