### PR TITLE
Use API base URL from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ react-hook-form, zod, Zustand.
     ```bash
     yarn install
     ```
+
+2. Для фронтенда можно настроить базовый URL API через переменную окружения
+   `VITE_API_BASE_URL`. По умолчанию используется `/api`. Локальные значения
+   можно задать в файле `apps/frontend/config/.local.env`.

--- a/apps/frontend/config/.local.env
+++ b/apps/frontend/config/.local.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/libs/dataAccess/src/lib/data-access.ts
+++ b/libs/dataAccess/src/lib/data-access.ts
@@ -7,7 +7,9 @@ import {
 } from '@async-workers/shared-types';
 
 class DataAccess {
-  private API = axios.create({ baseURL: '/api' });
+  private API = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
+  });
 
   public getAllJobs = async (status?: JobStatus): Promise<Job[]> => {
     const { data } = await this.API.get<Job[]>('/jobs', {

--- a/libs/dataAccess/tsconfig.lib.json
+++ b/libs/dataAccess/tsconfig.lib.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts", "../../types.d.ts"],
   "references": [


### PR DESCRIPTION
## Summary
- configure data-access base URL via `VITE_API_BASE_URL`
- provide type info for `import.meta.env`
- document the new variable
- add `.local.env` with default value

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888cd20643883309f052fed7abb0c7f