### PR TITLE
Fix toast remove delay and move to top-right

### DIFF
--- a/apps/frontend/src/components/ui/toast.tsx
+++ b/apps/frontend/src/components/ui/toast.tsx
@@ -15,7 +15,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 right-0 z-[100] flex max-h-screen w-full flex-col p-4 md:max-w-[420px]',
       className
     )}
     {...props}

--- a/apps/frontend/src/hooks/useToast.ts
+++ b/apps/frontend/src/hooks/useToast.ts
@@ -3,7 +3,8 @@ import React from 'react';
 import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
+const TOAST_REMOVE_DELAY =
+  Number(import.meta.env.VITE_TOAST_DELAY) || 5000;
 
 type ToasterToast = ToastProps & {
   id: string;


### PR DESCRIPTION
## Summary
- allow configuring toast duration via environment variable
- position toast viewport at the top right

## Testing
- `npx -y vite build --config apps/frontend/vite.config.ts` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68896376d4f08330b27b47fe29512cf6