### PR TITLE
Визуализация статистики и обновление главной страницы

### DIFF
--- a/apps/frontend/src/components/ui/ring-chart.tsx
+++ b/apps/frontend/src/components/ui/ring-chart.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { cn } from '@/utils/classnames';
+
+interface Segment {
+  value: number;
+  colorClass: string;
+}
+
+export interface RingChartProps {
+  segments: Segment[];
+  size?: number;
+  strokeWidth?: number;
+}
+
+export function RingChart({
+  segments,
+  size = 120,
+  strokeWidth = 12,
+}: RingChartProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  let offset = 0;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="-rotate-90"
+    >
+      <circle
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+        fill="transparent"
+        strokeWidth={strokeWidth}
+        className="stroke-muted"
+      />
+      {segments.map((seg, i) => {
+        const length = (seg.value / 100) * circumference;
+        const circle = (
+          <circle
+            key={i}
+            r={radius}
+            cx={size / 2}
+            cy={size / 2}
+            fill="transparent"
+            strokeWidth={strokeWidth}
+            className={cn(seg.colorClass, 'transition-all')}
+            strokeDasharray={`${length} ${circumference}`}
+            strokeDashoffset={-offset}
+            strokeLinecap="butt"
+          />
+        );
+        offset += length;
+        return circle;
+      })}
+    </svg>
+  );
+}
+
+export default RingChart;

--- a/apps/frontend/src/components/ui/ring-chart.tsx
+++ b/apps/frontend/src/components/ui/ring-chart.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { cn } from '@/utils/classnames';
 
 interface Segment {
   value: number;
   colorClass: string;
+  label: string;
+  count: number;
 }
 
 export interface RingChartProps {
@@ -19,43 +21,53 @@ export function RingChart({
 }: RingChartProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
+  const [hovered, setHovered] = useState<number | null>(null);
 
   let offset = 0;
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      className="-rotate-90"
-    >
-      <circle
-        r={radius}
-        cx={size / 2}
-        cy={size / 2}
-        fill="transparent"
-        strokeWidth={strokeWidth}
-        className="stroke-muted"
-      />
-      {segments.map((seg, i) => {
-        const length = (seg.value / 100) * circumference;
-        const circle = (
-          <circle
-            key={i}
-            r={radius}
-            cx={size / 2}
-            cy={size / 2}
-            fill="transparent"
-            strokeWidth={strokeWidth}
-            className={cn(seg.colorClass, 'transition-all')}
-            strokeDasharray={`${length} ${circumference}`}
-            strokeDashoffset={-offset}
-            strokeLinecap="butt"
-          />
-        );
-        offset += length;
-        return circle;
-      })}
-    </svg>
+    <div className="relative inline-flex" style={{ width: size, height: size }}>
+      {hovered !== null && (
+        <div className="absolute left-1/2 -top-2 z-10 -translate-x-1/2 -translate-y-full rounded-md border bg-popover px-2 py-1 text-xs shadow">
+          {segments[hovered].label}: {segments[hovered].count}
+        </div>
+      )}
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="-rotate-90"
+      >
+        <circle
+          r={radius}
+          cx={size / 2}
+          cy={size / 2}
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          className="stroke-muted"
+        />
+        {segments.map((seg, i) => {
+          const length = (seg.value / 100) * circumference;
+          const circle = (
+            <circle
+              key={i}
+              r={radius}
+              cx={size / 2}
+              cy={size / 2}
+              fill="transparent"
+              strokeWidth={hovered === i ? strokeWidth + 4 : strokeWidth}
+              className={cn(seg.colorClass, 'transition-all cursor-pointer')}
+              strokeDasharray={`${length} ${circumference}`}
+              strokeDashoffset={-offset}
+              strokeLinecap="butt"
+              onMouseEnter={() => setHovered(i)}
+              onMouseLeave={() => setHovered(null)}
+            />
+          );
+          offset += length;
+          return circle;
+        })}
+      </svg>
+    </div>
   );
 }
 

--- a/apps/frontend/src/hooks/useSortableData.ts
+++ b/apps/frontend/src/hooks/useSortableData.ts
@@ -1,0 +1,39 @@
+import { useState, useMemo } from 'react';
+
+export type SortDirection = 'asc' | 'desc';
+
+export function useSortableData<T>(data: T[]) {
+  const [sortKey, setSortKey] = useState<keyof T | null>(null);
+  const [direction, setDirection] = useState<SortDirection>('asc');
+
+  const sorted = useMemo(() => {
+    if (!sortKey) return data;
+    return [...data].sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return direction === 'asc' ? -1 : 1;
+      if (bVal == null) return direction === 'asc' ? 1 : -1;
+
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return direction === 'asc' ? aVal - bVal : bVal - aVal;
+      }
+
+      return direction === 'asc'
+        ? String(aVal).localeCompare(String(bVal))
+        : String(bVal).localeCompare(String(aVal));
+    });
+  }, [data, sortKey, direction]);
+
+  function requestSort(key: keyof T) {
+    if (sortKey === key) {
+      setDirection(direction === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setDirection('asc');
+    }
+  }
+
+  return { sorted, sortKey, direction, requestSort };
+}

--- a/apps/frontend/src/routes/dashboard.tsx
+++ b/apps/frontend/src/routes/dashboard.tsx
@@ -3,6 +3,8 @@ import { useJobsStats } from '@/utils/queries';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import RingChart from '@/components/ui/ring-chart';
+import { useSortableData } from '@/hooks/useSortableData';
+import { ArrowUpDown } from 'lucide-react';
 
 export default function DashboardPage() {
   const [days, setDays] = useState(7);
@@ -24,11 +26,45 @@ export default function DashboardPage() {
 
   const totalCount = totals.queued + totals.running + totals.done + totals.failed;
   const segments = [
-    { value: (totals.done / totalCount) * 100 || 0, colorClass: 'stroke-chart-1' },
-    { value: (totals.running / totalCount) * 100 || 0, colorClass: 'stroke-chart-2' },
-    { value: (totals.queued / totalCount) * 100 || 0, colorClass: 'stroke-chart-3' },
-    { value: (totals.failed / totalCount) * 100 || 0, colorClass: 'stroke-chart-4' },
+    {
+      value: (totals.done / totalCount) * 100 || 0,
+      colorClass: 'stroke-chart-1',
+      label: 'Выполнено',
+      count: totals.done,
+    },
+    {
+      value: (totals.running / totalCount) * 100 || 0,
+      colorClass: 'stroke-chart-2',
+      label: 'В процессе',
+      count: totals.running,
+    },
+    {
+      value: (totals.queued / totalCount) * 100 || 0,
+      colorClass: 'stroke-chart-3',
+      label: 'В очереди',
+      count: totals.queued,
+    },
+    {
+      value: (totals.failed / totalCount) * 100 || 0,
+      colorClass: 'stroke-chart-4',
+      label: 'Ошибки',
+      count: totals.failed,
+    },
   ];
+
+  const rows = useMemo(
+    () =>
+      stats?.map((d) => ({
+        startDate: d.startDate,
+        done: d.done.count,
+        running: d.running.count,
+        queued: d.queued.count,
+        failed: d.failed.count,
+      })) || [],
+    [stats]
+  );
+
+  const { sorted, sortKey, direction, requestSort } = useSortableData(rows);
 
   return (
     <div className="space-y-4">
@@ -81,23 +117,48 @@ export default function DashboardPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="text-left border-b">
-                <th className="py-2">Дата</th>
-                <th>Выполнено</th>
-                <th>В процессе</th>
-                <th>В очереди</th>
-                <th>Ошибки</th>
+                <th className="py-2 cursor-pointer" onClick={() => requestSort('startDate')}>
+                  <div className="flex items-center gap-1">
+                    Дата
+                    <ArrowUpDown className="size-3" />
+                  </div>
+                </th>
+                <th className="cursor-pointer" onClick={() => requestSort('done')}>
+                  <div className="flex items-center gap-1">
+                    Выполнено
+                    <ArrowUpDown className="size-3" />
+                  </div>
+                </th>
+                <th className="cursor-pointer" onClick={() => requestSort('running')}>
+                  <div className="flex items-center gap-1">
+                    В процессе
+                    <ArrowUpDown className="size-3" />
+                  </div>
+                </th>
+                <th className="cursor-pointer" onClick={() => requestSort('queued')}>
+                  <div className="flex items-center gap-1">
+                    В очереди
+                    <ArrowUpDown className="size-3" />
+                  </div>
+                </th>
+                <th className="cursor-pointer" onClick={() => requestSort('failed')}>
+                  <div className="flex items-center gap-1">
+                    Ошибки
+                    <ArrowUpDown className="size-3" />
+                  </div>
+                </th>
               </tr>
             </thead>
             <tbody>
-              {stats.map((day) => (
+              {sorted.map((day) => (
                 <tr key={day.startDate.toString()} className="border-b hover:bg-muted/50">
                   <td className="py-2">
                     {new Date(day.startDate).toLocaleDateString()}
                   </td>
-                  <td>{day.done.count}</td>
-                  <td>{day.running.count}</td>
-                  <td>{day.queued.count}</td>
-                  <td>{day.failed.count}</td>
+                  <td>{day.done}</td>
+                  <td>{day.running}</td>
+                  <td>{day.queued}</td>
+                  <td>{day.failed}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/frontend/src/routes/dashboard.tsx
+++ b/apps/frontend/src/routes/dashboard.tsx
@@ -1,38 +1,108 @@
-import { useJobsSummary, useJobsStats } from '@/utils/queries';
+import { useState, useMemo } from 'react';
+import { useJobsStats } from '@/utils/queries';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import RingChart from '@/components/ui/ring-chart';
 
 export default function DashboardPage() {
-  const { data: summary } = useJobsSummary();
-  const { data: stats } = useJobsStats();
+  const [days, setDays] = useState(7);
+  const { data: stats, isLoading } = useJobsStats(days);
+
+  const totals = useMemo(() => {
+    if (!stats) return { queued: 0, running: 0, done: 0, failed: 0 };
+    return stats.reduce(
+      (acc, d) => {
+        acc.queued += d.queued.count;
+        acc.running += d.running.count;
+        acc.done += d.done.count;
+        acc.failed += d.failed.count;
+        return acc;
+      },
+      { queued: 0, running: 0, done: 0, failed: 0 }
+    );
+  }, [stats]);
+
+  const totalCount = totals.queued + totals.running + totals.done + totals.failed;
+  const segments = [
+    { value: (totals.done / totalCount) * 100 || 0, colorClass: 'stroke-chart-1' },
+    { value: (totals.running / totalCount) * 100 || 0, colorClass: 'stroke-chart-2' },
+    { value: (totals.queued / totalCount) * 100 || 0, colorClass: 'stroke-chart-3' },
+    { value: (totals.failed / totalCount) * 100 || 0, colorClass: 'stroke-chart-4' },
+  ];
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      {summary ? (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-card p-4 rounded-md shadow">
-            <div className="text-sm text-muted-foreground">Всего</div>
-            <div className="text-2xl font-bold">{summary.total}</div>
-          </div>
-          <div className="bg-card p-4 rounded-md shadow">
-            <div className="text-sm text-muted-foreground">Выполнено</div>
-            <div className="text-2xl font-bold">{summary.done.count}</div>
-          </div>
-          <div className="bg-card p-4 rounded-md shadow">
-            <div className="text-sm text-muted-foreground">В процессе</div>
-            <div className="text-2xl font-bold">{summary.running.count}</div>
-          </div>
-          <div className="bg-card p-4 rounded-md shadow">
-            <div className="text-sm text-muted-foreground">Ошибки</div>
-            <div className="text-2xl font-bold">{summary.failed.count}</div>
-          </div>
-        </div>
-      ) : (
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button size="sm" variant={days === 7 ? 'default' : 'outline'} onClick={() => setDays(7)}>
+          Неделя
+        </Button>
+        <Button size="sm" variant={days === 30 ? 'default' : 'outline'} onClick={() => setDays(30)}>
+          Месяц
+        </Button>
+        <Button size="sm" variant={days === 365 ? 'default' : 'outline'} onClick={() => setDays(365)}>
+          Год
+        </Button>
+        <Input
+          type="number"
+          min={1}
+          value={days}
+          onChange={(e) => setDays(parseInt(e.target.value) || 1)}
+          className="w-20"
+        />
+      </div>
+
+      {isLoading ? (
         <div>Загрузка...</div>
-      )}
-      {stats ? (
-        <pre className="bg-muted p-2 rounded-md text-sm overflow-x-auto">
-          {JSON.stringify(stats, null, 2)}
-        </pre>
+      ) : stats ? (
+        <div className="space-y-4">
+          <div className="flex flex-col items-center">
+            <RingChart segments={segments} />
+            <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+              <div className="flex items-center gap-2">
+                <span className="size-3 rounded-full bg-chart-1" />
+                Выполнено: {totals.done}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="size-3 rounded-full bg-chart-2" />
+                В процессе: {totals.running}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="size-3 rounded-full bg-chart-3" />
+                В очереди: {totals.queued}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="size-3 rounded-full bg-chart-4" />
+                Ошибки: {totals.failed}
+              </div>
+            </div>
+          </div>
+
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">Дата</th>
+                <th>Выполнено</th>
+                <th>В процессе</th>
+                <th>В очереди</th>
+                <th>Ошибки</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.map((day) => (
+                <tr key={day.startDate.toString()} className="border-b hover:bg-muted/50">
+                  <td className="py-2">
+                    {new Date(day.startDate).toLocaleDateString()}
+                  </td>
+                  <td>{day.done.count}</td>
+                  <td>{day.running.count}</td>
+                  <td>{day.queued.count}</td>
+                  <td>{day.failed.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : null}
     </div>
   );

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -1,19 +1,20 @@
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+
 export default function IndexPage() {
   return (
-    <div className="flex flex-col items-center justify-center h-full">
-      <h1 className="text-3xl font-bold mb-4">
-        Добро пожаловать в AsyncWorkers Dashboard
-      </h1>
-      <p className="text-muted-foreground mb-6">
-        Здесь будет отображаться список фоновых задач.
-      </p>
-      <div className="bg-card text-card-foreground p-6 rounded-lg shadow-md w-full max-w-md">
-        <h2 className="text-xl font-semibold mb-2">Начало работы</h2>
-        <ul className="list-disc pl-5 space-y-1">
-          <li>Создайте новую задачу</li>
-          <li>Отслеживайте прогресс выполнения</li>
-          <li>Получайте уведомления о завершении</li>
-        </ul>
+    <div className="flex flex-col items-center justify-center h-full text-center space-y-6">
+      <div>
+        <h1 className="text-4xl font-bold mb-2">Добро пожаловать в AsyncWorkers</h1>
+        <p className="text-muted-foreground">Управляйте задачами и следите за их выполнением.</p>
+      </div>
+      <div className="flex gap-4">
+        <Button asChild>
+          <Link to="/dashboard">Перейти к дашборду</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link to="/jobs">Список задач</Link>
+        </Button>
       </div>
     </div>
   );

--- a/apps/frontend/src/routes/jobs/index.tsx
+++ b/apps/frontend/src/routes/jobs/index.tsx
@@ -5,10 +5,13 @@ import { useJobs } from '@/hooks/useJobStore';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import NewJob from '@/components/modals/newJob';
+import { useSortableData } from '@/hooks/useSortableData';
+import { ArrowUpDown } from 'lucide-react';
 
 export default function JobsPage() {
   const { isLoading } = useJobsQuery();
   const jobs = useJobs();
+  const { sorted, requestSort } = useSortableData(jobs);
 
   useSseListener('all');
 
@@ -30,13 +33,28 @@ export default function JobsPage() {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left border-b">
-              <th className="py-2">Название</th>
-              <th>Статус</th>
-              <th>Прогресс</th>
+              <th className="py-2 cursor-pointer" onClick={() => requestSort('name')}>
+                <div className="flex items-center gap-1">
+                  Название
+                  <ArrowUpDown className="size-3" />
+                </div>
+              </th>
+              <th className="cursor-pointer" onClick={() => requestSort('status')}>
+                <div className="flex items-center gap-1">
+                  Статус
+                  <ArrowUpDown className="size-3" />
+                </div>
+              </th>
+              <th className="cursor-pointer" onClick={() => requestSort('progress')}>
+                <div className="flex items-center gap-1">
+                  Прогресс
+                  <ArrowUpDown className="size-3" />
+                </div>
+              </th>
             </tr>
           </thead>
           <tbody>
-            {jobs.map((job) => (
+            {sorted.map((job) => (
               <tr key={job.id} className="border-b hover:bg-muted/50">
                 <td className="py-2">
                   <Link to={`/jobs/${job.id}`} className="underline">


### PR DESCRIPTION
## Изменения
- добавлен компонент `RingChart` для рисования кольцевых диаграмм
- на дашборде можно выбрать период статистики (неделя, месяц, год или любое количество дней)
- в дашборде отображается кольцевая диаграмма с распределением задач и таблица с детализацией по дням
- обновлена главная страница с кнопками перехода к дашборду и списку задач

## Тестирование
- `npx tsc -p apps/frontend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b3aff494c83309946c65da2c8c392